### PR TITLE
chore: Enable Multi Subnet Failover in connection

### DIFF
--- a/tap_mssql/connection.py
+++ b/tap_mssql/connection.py
@@ -47,7 +47,6 @@ class MSSQLConnection:
 
     def _pyodbc_conn_str(self, config):
         return (
-            # f"DRIVER={{ODBC Driver 18 for SQL Server}};"
             f"DRIVER={{ODBC Driver 18 for SQL Server}};"
             f"SERVER={config['host']};"
             f"DATABASE={config['database']};"
@@ -55,7 +54,7 @@ class MSSQLConnection:
             f"PWD={config.get('password')};"
             f"PORT={config.get('port', '1433')};"
             f"CHARSET={config.get('characterset', 'utf8')};"
-            # f"TDS_Version={config.get('tds_version', '7.3')};"
+            f"MultiSubnetFailover={config.get('multi_subnet_failover', 'Yes')};"
         )
 
     def __enter__(self):


### PR DESCRIPTION
Default `MultiSubnetFailover` to `Yes`. 

Goal is to fix this error:
```
sqlalchemy.exc.OperationalError: (pyodbc.OperationalError) ('HYT00', '[HYT00] [Microsoft][ODBC Driver 17 for SQL Server]Login timeout expired (0) (SQLDriverConnect)')
```

Fix found in an alternative SQL Server tap:
https://github.com/BuzzCutNorman/tap-mssql?tab=readme-ov-file#troubleshooting

https://learn.microsoft.com/en-us/sql/relational-databases/native-client/applications/using-connection-string-keywords-with-sql-server-native-client?view=sql-server-ver15&viewFallbackFrom=sql-server-ver16

https://learn.microsoft.com/en-us/sql/relational-databases/native-client/features/sql-server-native-client-support-for-high-availability-disaster-recovery?view=sql-server-ver15#connecting-with-multisubnetfailover